### PR TITLE
fix: use public deploy-slack-action so release resolves in public repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
 
       - name: Start Deploy Message
-        uses: Basis-Theory/github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
@@ -47,7 +47,7 @@ jobs:
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}


### PR DESCRIPTION
## Description
- The Release workflow referenced `Basis-Theory/github-actions/deploy-slack-action@master`, but `Basis-Theory/github-actions` is not resolvable from this **public** repo, so the `build-release` job failed at "Set up job" with `Unable to resolve action ... not found` (surfaced by the first release trigger in a while).
- Point both Slack steps at the public `Basis-Theory/public-github-actions/deploy-slack-action@master` (the same action every other repo uses), which public repos can resolve.
- Minimal hotfix to unbreak releases on master; independent of the ENG-11425 token migration (#40 carries the SHA-pinned version).

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change